### PR TITLE
Configure Livewire assets publishing and enhance backend validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,9 @@ jobs:
 
       - name: Install PHP dependencies
         run: composer install --no-dev --optimize-autoloader
+      
+      - name: Publish Livewire assets
+        run: php artisan vendor:publish --force --tag=livewire:assets
 
       - name: Install Node.js
         uses: actions/setup-node@v3

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,12 +3,14 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class User extends Authenticatable
+class User extends Authenticatable implements FilamentUser
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable, SoftDeletes;
@@ -45,5 +47,12 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        $valid_users = explode(',', config('app.filament.admins'));
+
+        return in_array($this->email, $valid_users);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,7 +9,9 @@ use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Vite;
+use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
+use Livewire\Livewire;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -34,6 +36,14 @@ class AppServiceProvider extends ServiceProvider
 
         if (App::environment('production')) {
             URL::forceScheme('https');
+
+            Livewire::setScriptRoute(function ( $handle ) {
+                return Route::get('/livewire/live-wire-js', $handle);
+            });
+
+            Livewire::setUpdateRoute(function ($handle) {
+                return Route::post('/livewire/update', $handle);
+            });
         }
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -123,4 +123,8 @@ return [
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
 
+    'filament' => [
+        'admins' => env('FILAMENT_ADMIN_USERS', []),
+    ],
+
 ];


### PR DESCRIPTION
## Summary
This PR introduces improvements to both the CI/CD workflow and the backend:

### ✅ CI/CD
- Added GitHub Action step to publish Livewire assets (`php artisan vendor:publish --force --tag=livewire:assets`).

### ✅ Backend
- Added user validation when accessing the Filament admin panel.
- Added routes to properly serve Livewire assets.

## Motivation
- Ensure that Livewire assets are always published and available in the `public` folder after deployment.
- Improve security by validating user access to the Filament admin panel.
- Guarantee Livewire routes are accessible for a stable frontend experience.

## Related
Closes #<issue_number_if_any>
